### PR TITLE
Support for Binary Data

### DIFF
--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSBinaryInputDStream.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSBinaryInputDStream.scala
@@ -26,30 +26,30 @@ import org.apache.spark.streaming.dstream.ReceiverInputDStream
 import org.apache.spark.streaming.receiver.Receiver
 
 private[streaming]
-class MQTTSInputDStream(
-                       ssc : StreamingContext,
-                       brokerUrl: String,
-                       topic: String,
-                       caCert: X509Certificate,
-                       cert: X509Certificate,
-                       privateKey: PrivateKey,
-                       storageLevel: StorageLevel
-                       ) extends ReceiverInputDStream[String](ssc) {
-  def getReceiver(): Receiver[String] = {
-    new MQTTSStringReceiver(brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+class MQTTSBinaryInputDStream(
+                         ssc : StreamingContext,
+                         brokerUrl: String,
+                         topic: String,
+                         caCert: X509Certificate,
+                         cert: X509Certificate,
+                         privateKey: PrivateKey,
+                         storageLevel: StorageLevel
+                       ) extends ReceiverInputDStream[Array[Byte]](ssc) {
+  def getReceiver(): Receiver[Array[Byte]] = {
+    new MQTTSBinaryReceiver(brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 }
 
 private[streaming]
-class MQTTSStringReceiver(
-                   brokerUrl: String,
-                   topic: String,
-                   caCert: X509Certificate,
-                   cert: X509Certificate,
-                   privateKey: PrivateKey,
-                   storageLevel: StorageLevel
-                   ) extends MQTTSReceiver[String](brokerUrl, topic, caCert, cert, privateKey, storageLevel) {
+class MQTTSBinaryReceiver(
+                     brokerUrl: String,
+                     topic: String,
+                     caCert: X509Certificate,
+                     cert: X509Certificate,
+                     privateKey: PrivateKey,
+                     storageLevel: StorageLevel
+                   ) extends MQTTSReceiver[Array[Byte]](brokerUrl, topic, caCert, cert, privateKey, storageLevel) {
   def processMessage(payload: Array[Byte]): Unit = {
-    store(new String(payload, "utf-8"))
+    store(payload)
   }
 }

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSInputDStream.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSInputDStream.scala
@@ -29,7 +29,7 @@ import org.eclipse.paho.client.mqttv3._
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 
 private[streaming]
-class MQTTSInputDStream(
+class MQTTSInputDStream[A](
                        ssc : StreamingContext,
                        brokerUrl: String,
                        topic: String,
@@ -37,21 +37,21 @@ class MQTTSInputDStream(
                        cert: X509Certificate,
                        privateKey: PrivateKey,
                        storageLevel: StorageLevel
-                       ) extends ReceiverInputDStream[String](ssc) {
-  def getReceiver(): Receiver[String] = {
-    new MQTTSReceiver(brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+                       ) extends ReceiverInputDStream[A](ssc) {
+  def getReceiver(): Receiver[A] = {
+    new MQTTSReceiver[A](brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 }
 
 private[streaming]
-class MQTTSReceiver(
+class MQTTSReceiver[A](
                    brokerUrl: String,
                    topic: String,
                    caCert: X509Certificate,
                    cert: X509Certificate,
                    privateKey: PrivateKey,
                    storageLevel: StorageLevel
-                   ) extends Receiver[String](storageLevel) {
+                   ) extends Receiver[A](storageLevel) {
   def onStart(): Unit = {
     // Set up persistence for messages
     val persistence = new MemoryPersistence()
@@ -92,7 +92,7 @@ class MQTTSReceiver(
 
       // Handles Mqtt message
       override def messageArrived(topic: String, message: MqttMessage) {
-        store(new String(message.getPayload, "utf-8"))
+        store(new A(message.getPayload, "utf-8"))
       }
 
       override def deliveryComplete(token: IMqttDeliveryToken) {

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSInputDStream.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSInputDStream.scala
@@ -29,7 +29,7 @@ import org.eclipse.paho.client.mqttv3._
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 
 private[streaming]
-class MQTTSInputDStream[A](
+class MQTTSInputDStream(
                        ssc : StreamingContext,
                        brokerUrl: String,
                        topic: String,
@@ -37,21 +37,21 @@ class MQTTSInputDStream[A](
                        cert: X509Certificate,
                        privateKey: PrivateKey,
                        storageLevel: StorageLevel
-                       ) extends ReceiverInputDStream[A](ssc) {
-  def getReceiver(): Receiver[A] = {
-    new MQTTSReceiver[A](brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+                       ) extends ReceiverInputDStream[String](ssc) {
+  def getReceiver(): Receiver[String] = {
+    new MQTTSReceiver(brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 }
 
 private[streaming]
-class MQTTSReceiver[A](
+class MQTTSReceiver(
                    brokerUrl: String,
                    topic: String,
                    caCert: X509Certificate,
                    cert: X509Certificate,
                    privateKey: PrivateKey,
                    storageLevel: StorageLevel
-                   ) extends Receiver[A](storageLevel) {
+                   ) extends Receiver[String](storageLevel) {
   def onStart(): Unit = {
     // Set up persistence for messages
     val persistence = new MemoryPersistence()
@@ -92,7 +92,7 @@ class MQTTSReceiver[A](
 
       // Handles Mqtt message
       override def messageArrived(topic: String, message: MqttMessage) {
-        store(new A(message.getPayload, "utf-8"))
+        store(new String(message.getPayload, "utf-8"))
       }
 
       override def deliveryComplete(token: IMqttDeliveryToken) {

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSReceiver.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSReceiver.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package co.verdigris.spark.streaming.mqtts
+
+import java.security.{KeyStore, PrivateKey}
+import java.security.cert.X509Certificate
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
+
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.receiver.Receiver
+import org.eclipse.paho.client.mqttv3._
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
+
+private[streaming]
+abstract class MQTTSReceiver[T](
+                                                 brokerUrl: String,
+                                                 topic: String,
+                                                 caCert: X509Certificate,
+                                                 cert: X509Certificate,
+                                                 privateKey: PrivateKey,
+                                                 storageLevel: StorageLevel
+                                               ) extends Receiver[T](storageLevel) {
+  protected val client = new MqttClient(brokerUrl, MqttClient.generateClientId, new MemoryPersistence())
+  protected val connectOptions = new MqttConnectOptions()
+  protected val callback = new MqttCallback() {
+    override def messageArrived(topic: String, message: MqttMessage): Unit = {
+      processMessage(message.getPayload)
+    }
+
+    override def deliveryComplete(iMqttDeliveryToken: IMqttDeliveryToken) {}
+
+    override def connectionLost(cause: Throwable): Unit = {
+      restart("Connection lost ", cause)
+    }
+  }
+  protected val caKeyStore = KeyStore.getInstance(KeyStore.getDefaultType)
+  protected val clientKeyStore = KeyStore.getInstance(KeyStore.getDefaultType)
+  protected val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+  protected val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+  protected val sslContext = SSLContext.getInstance("TLSv1.2")
+
+
+  def processMessage(payload: Array[Byte])
+
+  def onStart(): Unit = {
+    // Store CA certificate in JKS
+    caKeyStore.load(null, null)
+    caKeyStore.setCertificateEntry("ca-certificate", caCert)
+
+    // Establish certificate trust chain
+    trustManagerFactory.init(caKeyStore)
+
+    // Store client certificate and private key in JKS
+    clientKeyStore.load(null, null)
+    clientKeyStore.setCertificateEntry("certificate", cert)
+    clientKeyStore.setKeyEntry("private-key", privateKey, new Array[Char](0), Array(cert))
+
+    // Initialize key manager from the key store
+    keyManagerFactory.init(clientKeyStore, new Array[Char](0))
+
+    // Set up client certificate for connection over TLS 1.2
+    sslContext.init(keyManagerFactory.getKeyManagers, trustManagerFactory.getTrustManagers, null)
+
+    // Set connect options to use the TLS enabled socket factory
+    connectOptions.setSocketFactory(sslContext.getSocketFactory)
+
+    // Set callback for MqttClient. This needs to happen before connecting or subscribing, other message may be lost.
+    client.setCallback(callback)
+
+    // Connect to MqttBroker
+    client.connect(connectOptions)
+
+    // Subscribe to MQTT topic
+    client.subscribe(topic)
+  }
+
+  def onStop(): Unit = {}
+}

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -33,7 +33,7 @@ import sun.security.provider.X509Factory
 
 object MQTTSUtils {
   /**
-    * Create an input stream that receives messages pushed by a MQTT publisher.
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
     *
     * @param jssc       JavaStreamingContext object
     * @param brokerUrl  Url of remote MQTT publisher
@@ -55,7 +55,7 @@ object MQTTSUtils {
   }
 
   /**
-    * Create an input stream that receives messages pushed by a MQTT publisher.
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
     *
     * @param jssc         JavaStreamingContext object
     * @param brokerUrl    Url of remote MQTT publisher
@@ -79,7 +79,7 @@ object MQTTSUtils {
   }
 
   /**
-    * Create an input stream that receives messages pushed by a MQTT publisher.
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
     *
     * @param ssc          StreamingContext object
     * @param brokerUrl    Url of remote MQTT publisher
@@ -105,7 +105,7 @@ object MQTTSUtils {
   }
 
   /**
-    * Create an input stream that receives messages pushed by a MQTT publisher.
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
     *
     * @param ssc          StreamingContext object
     * @param brokerUrl    Url of remote MQTT publisher
@@ -133,7 +133,7 @@ object MQTTSUtils {
   }
 
   /**
-    * Create an input stream that receives messages pushed by a MQTT publisher.
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
     *
     * @param ssc          StreamingContext object
     * @param brokerUrl    Url of remote MQTT publisher

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -127,6 +127,8 @@ object MQTTSUtils {
                     storageLevel: StorageLevel
                   ): ReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    val cf = CertificateFactory.getInstance("X.509")
+
     val _caCert = stringToX509Certificate(caCert)
     val _cert = stringToX509Certificate(cert)
     val _privateKey = stringToPrivateKey(privateKey)
@@ -154,34 +156,7 @@ object MQTTSUtils {
                     privateKey: PrivateKey,
                     storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
                   ): ReceiverInputDStream[String] = {
-    new MQTTSInputDStream[String](ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
-  }
-
-  def createBinaryStream(
-                          ssc: StreamingContext,
-                          brokerUrl: String,
-                          topic: String,
-                          caCert: String,
-                          cert: String,
-                          privateKey: String
-                        ): ReceiverInputDStream[Array[Byte]] = {
-    val _caCert = stringToX509Certificate(caCert)
-    val _cert = stringToX509Certificate(cert)
-    val _privateKey = stringToPrivateKey(privateKey)
-
-    createBinaryStream(ssc, brokerUrl, topic, _caCert, _cert, _privateKey)
-  }
-
-  def createBinaryStream(
-                          ssc: StreamingContext,
-                          brokerUrl: String,
-                          topic: String,
-                          caCert: X509Certificate,
-                          cert: X509Certificate,
-                          privateKey: PrivateKey,
-                          storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-                        ): ReceiverInputDStream[Array[Byte]] = {
-    new MQTTSInputDStream[Array[Byte]](ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+    new MQTTSInputDStream(ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 
   private def stringToX509Certificate(cert: String): X509Certificate = {

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -127,8 +127,6 @@ object MQTTSUtils {
                     storageLevel: StorageLevel
                   ): ReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
-    val cf = CertificateFactory.getInstance("X.509")
-
     val _caCert = stringToX509Certificate(caCert)
     val _cert = stringToX509Certificate(cert)
     val _privateKey = stringToPrivateKey(privateKey)
@@ -156,7 +154,34 @@ object MQTTSUtils {
                     privateKey: PrivateKey,
                     storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
                   ): ReceiverInputDStream[String] = {
-    new MQTTSInputDStream(ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+    new MQTTSInputDStream[String](ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+  }
+
+  def createBinaryStream(
+                          ssc: StreamingContext,
+                          brokerUrl: String,
+                          topic: String,
+                          caCert: String,
+                          cert: String,
+                          privateKey: String
+                        ): ReceiverInputDStream[Array[Byte]] = {
+    val _caCert = stringToX509Certificate(caCert)
+    val _cert = stringToX509Certificate(cert)
+    val _privateKey = stringToPrivateKey(privateKey)
+
+    createBinaryStream(ssc, brokerUrl, topic, _caCert, _cert, _privateKey)
+  }
+
+  def createBinaryStream(
+                          ssc: StreamingContext,
+                          brokerUrl: String,
+                          topic: String,
+                          caCert: X509Certificate,
+                          cert: X509Certificate,
+                          privateKey: PrivateKey,
+                          storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
+                        ): ReceiverInputDStream[Array[Byte]] = {
+    new MQTTSInputDStream[Array[Byte]](ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 
   private def stringToX509Certificate(cert: String): X509Certificate = {

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -42,6 +42,129 @@ object MQTTSUtils {
     * @param cert       Client certificate associated with the MQTT client
     * @param privateKey :  Private key associated with the MQTT client
     */
+  def createBinaryStream(
+                    jssc: JavaStreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: X509Certificate,
+                    cert: X509Certificate,
+                    privateKey: PrivateKey
+                  ): JavaReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    createBinaryStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param jssc         JavaStreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert         Client certificate associated with the MQTT client
+    * @param privateKey   Private key associated with the MQTT client
+    * @param storageLevel RDD storage level.
+    */
+  def createBinaryStream(
+                    jssc: JavaStreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: X509Certificate,
+                    cert: X509Certificate,
+                    privateKey: PrivateKey,
+                    storageLevel: StorageLevel
+                  ): JavaReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    createBinaryStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param ssc          StreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate Authority's certificate in base64 encoded PEM formatted string
+    * @param cert         Client certificate in base64 encoded PEM formatted string
+    * @param privateKey   Private key in PKCS8 formatted string
+    */
+  def createBinaryStream(
+                    ssc: StreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: String,
+                    cert: String,
+                    privateKey: String
+                  ): ReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    val _caCert = stringToX509Certificate(caCert)
+    val _cert = stringToX509Certificate(cert)
+    val _privateKey = stringToPrivateKey(privateKey)
+
+    createBinaryStream(ssc, brokerUrl, topic, _caCert, _cert, _privateKey)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param ssc          StreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate Authority's certificate in base64 encoded PEM formatted string
+    * @param cert         Client certificate in base64 encoded PEM formatted string
+    * @param privateKey   Private key in PKCS8 formatted string
+    * @param storageLevel RDD storage level.
+    */
+  def createBinaryStream(
+                    ssc: StreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: String,
+                    cert: String,
+                    privateKey: String,
+                    storageLevel: StorageLevel
+                  ): ReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    val _caCert = stringToX509Certificate(caCert)
+    val _cert = stringToX509Certificate(cert)
+    val _privateKey = stringToPrivateKey(privateKey)
+
+    createBinaryStream(ssc, brokerUrl, topic, _caCert, _cert, _privateKey, storageLevel)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param ssc          StreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert         Client certificate associated with the MQTT client
+    * @param privateKey   Private key associated with the MQTT client
+    * @param storageLevel RDD storage level.
+    */
+  def createBinaryStream(
+                    ssc: StreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: X509Certificate,
+                    cert: X509Certificate,
+                    privateKey: PrivateKey,
+                    storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
+                  ): ReceiverInputDStream[Array[Byte]] = {
+    new MQTTSBinaryInputDStream(ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param jssc       JavaStreamingContext object
+    * @param brokerUrl  Url of remote MQTT publisher
+    * @param topic      Topic name to subscribe to
+    * @param caCert     Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert       Client certificate associated with the MQTT client
+    * @param privateKey :  Private key associated with the MQTT client
+    */
   def createStream(
                     jssc: JavaStreamingContext,
                     brokerUrl: String,

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -43,6 +43,52 @@ object MQTTSUtils {
     * @param privateKey :  Private key associated with the MQTT client
     */
   def createBinaryStream(
+                          jssc: JavaStreamingContext,
+                          brokerUrl: String,
+                          topic: String,
+                          caCert: String,
+                          cert: String,
+                          privateKey: String
+                        ): JavaReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    createBinaryStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey)
+  }
+
+  /**
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
+    *
+    * @param jssc         JavaStreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert         Client certificate associated with the MQTT client
+    * @param privateKey   Private key associated with the MQTT client
+    * @param storageLevel RDD storage level.
+    */
+  def createBinaryStream(
+                          jssc: JavaStreamingContext,
+                          brokerUrl: String,
+                          topic: String,
+                          caCert: String,
+                          cert: String,
+                          privateKey: String,
+                          storageLevel: StorageLevel
+                        ): JavaReceiverInputDStream[Array[Byte]] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[Array[Byte]]]
+    createBinaryStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+  }
+
+  /**
+    * Create an input stream that receives binary messages pushed by a MQTT publisher.
+    *
+    * @param jssc       JavaStreamingContext object
+    * @param brokerUrl  Url of remote MQTT publisher
+    * @param topic      Topic name to subscribe to
+    * @param caCert     Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert       Client certificate associated with the MQTT client
+    * @param privateKey :  Private key associated with the MQTT client
+    */
+  def createBinaryStream(
                     jssc: JavaStreamingContext,
                     brokerUrl: String,
                     topic: String,
@@ -153,6 +199,52 @@ object MQTTSUtils {
                     storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
                   ): ReceiverInputDStream[Array[Byte]] = {
     new MQTTSBinaryInputDStream(ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param jssc       JavaStreamingContext object
+    * @param brokerUrl  Url of remote MQTT publisher
+    * @param topic      Topic name to subscribe to
+    * @param caCert     Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert       Client certificate associated with the MQTT client
+    * @param privateKey :  Private key associated with the MQTT client
+    */
+  def createStream(
+                    jssc: JavaStreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: String,
+                    cert: String,
+                    privateKey: String
+                  ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey)
+  }
+
+  /**
+    * Create an input stream that receives messages pushed by a MQTT publisher.
+    *
+    * @param jssc         JavaStreamingContext object
+    * @param brokerUrl    Url of remote MQTT publisher
+    * @param topic        Topic name to subscribe to
+    * @param caCert       Certificate of Certificate Authority of remote MQTT publisher
+    * @param cert         Client certificate associated with the MQTT client
+    * @param privateKey   Private key associated with the MQTT client
+    * @param storageLevel RDD storage level.
+    */
+  def createStream(
+                    jssc: JavaStreamingContext,
+                    brokerUrl: String,
+                    topic: String,
+                    caCert: String,
+                    cert: String,
+                    privateKey: String,
+                    storageLevel: StorageLevel
+                  ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, brokerUrl, topic, caCert, cert, privateKey, storageLevel)
   }
 
   /**

--- a/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
+++ b/src/main/scala/co/verdigris/spark/streaming/mqtts/MQTTSUtils.scala
@@ -220,8 +220,6 @@ object MQTTSUtils {
                     privateKey: String
                   ): ReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
-    val cf = CertificateFactory.getInstance("X.509")
-
     val _caCert = stringToX509Certificate(caCert)
     val _cert = stringToX509Certificate(cert)
     val _privateKey = stringToPrivateKey(privateKey)
@@ -250,8 +248,6 @@ object MQTTSUtils {
                     storageLevel: StorageLevel
                   ): ReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
-    val cf = CertificateFactory.getInstance("X.509")
-
     val _caCert = stringToX509Certificate(caCert)
     val _cert = stringToX509Certificate(cert)
     val _privateKey = stringToPrivateKey(privateKey)


### PR DESCRIPTION
Sending binary data over MQTT would result in mangling due to the built-in charset encoding performed by the String class.

This PR adds support for handling binary data by adding `createBinaryStream` methods which returns a byte array.
